### PR TITLE
DC-440: Moved the get Message list to be called with the EntityResolv…

### DIFF
--- a/app/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnector.scala
+++ b/app/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnector.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilemessages.connector
+
+import uk.gov.hmrc.domain.SaUtr
+import uk.gov.hmrc.mobilemessages.config.WSHttp
+import uk.gov.hmrc.mobilemessages.domain.MessageHeader
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EntityResolverConnector extends SessionCookieEncryptionSupport {
+
+  def http: HttpGet
+
+  val entityResolverBaseUrl: String
+
+  private val returnReadAndUnreadMessages = "Both"
+
+  def messages(utr: SaUtr)
+              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = {
+    http.GET[Seq[MessageHeader]](s"$entityResolverBaseUrl/message/sa/$utr?read=$returnReadAndUnreadMessages")
+  }
+}
+
+object EntityResolverConnector extends EntityResolverConnector with ServicesConfig {
+  override def http = WSHttp
+
+  override lazy val entityResolverBaseUrl: String = baseUrl("entity-resolver")
+}
+

--- a/app/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnector.scala
+++ b/app/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnector.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.mobilemessages.connector
 
-import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.mobilemessages.config.WSHttp
 import uk.gov.hmrc.mobilemessages.domain.MessageHeader
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -32,9 +31,8 @@ trait EntityResolverConnector extends SessionCookieEncryptionSupport {
 
   private val returnReadAndUnreadMessages = "Both"
 
-  def messages(utr: SaUtr)
-              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = {
-    http.GET[Seq[MessageHeader]](s"$entityResolverBaseUrl/message/sa/$utr?read=$returnReadAndUnreadMessages")
+  def messages(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = {
+    http.GET[Seq[MessageHeader]](s"$entityResolverBaseUrl/messages?read=$returnReadAndUnreadMessages")
   }
 }
 

--- a/app/uk/gov/hmrc/mobilemessages/connector/MessageConnector.scala
+++ b/app/uk/gov/hmrc/mobilemessages/connector/MessageConnector.scala
@@ -47,11 +47,6 @@ trait MessageConnector extends SessionCookieEncryptionSupport {
 
   def now: DateTime
 
-  private val returnReadAndUnreadMessages = "Both"
-
-  def messages(utr: SaUtr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] =
-    http.GET[Seq[MessageHeader]](s"$messageBaseUrl/message/sa/$utr?read=$returnReadAndUnreadMessages")
-
   def readMessageContent(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext, auth: Option[Authority]): Future[Html] = {
     import RestFormats.dateTimeWrite
 

--- a/app/uk/gov/hmrc/mobilemessages/sandbox/DomainGenerator.scala
+++ b/app/uk/gov/hmrc/mobilemessages/sandbox/DomainGenerator.scala
@@ -42,7 +42,7 @@ object DomainGenerator {
       "You have a new tax statement",
       dateTime.minusDays(3).toLocalDate,
       Some(dateTime.minusDays(1)),
-      s"/message/sa/$saUtr/$readMessageId/read-time",
+      s"/entities/some-entityId/messages/$readMessageId/read-time",
       false)
   }
   def readMessageHeaderJson(implicit dateTime:DateTime) = Json.toJson(readMessageHeader())
@@ -52,7 +52,7 @@ object DomainGenerator {
     "Stopping Self Assessment",
     dateTime.toLocalDate,
     None,
-    s"/message/sa/$saUtr/$unreadMessageId/read-time",
+    s"/entities/some-entityId/messages/$unreadMessageId/read-time",
     false)
   def unreadMessageHeaderJson(implicit dateTime:DateTime) = Json.toJson(unreadMessageHeader())
 

--- a/app/uk/gov/hmrc/mobilemessages/services/MobileMessagesService.scala
+++ b/app/uk/gov/hmrc/mobilemessages/services/MobileMessagesService.scala
@@ -41,6 +41,7 @@ trait LiveMobileMessagesService extends MobileMessagesService with Auditor {
   def authConnector: AuthConnector
 
   def messageConnector : MessageConnector
+  def entityResolverConnector : EntityResolverConnector
 
   override def readAndUnreadMessages()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] ={
     withAudit("readAndUnreadMessages", Map.empty) {
@@ -53,7 +54,7 @@ trait LiveMobileMessagesService extends MobileMessagesService with Auditor {
 
   private def messages(maybeSaUtr : Option[SaUtr])(implicit hc: HeaderCarrier, ec: ExecutionContext) : Future[Seq[MessageHeader]] =
     maybeSaUtr match {
-      case Some(utr) => messageConnector.messages(utr)
+      case Some(utr) => entityResolverConnector.messages(utr)
       case _ => Future.successful(Seq.empty)
     }
 
@@ -93,6 +94,8 @@ object LiveMobileMessagesService extends LiveMobileMessagesService {
   override val authConnector: AuthConnector = AuthConnector
 
   override val messageConnector: MessageConnector = MessageConnector
+
+  override val entityResolverConnector: EntityResolverConnector = EntityResolverConnector
 
   val auditConnector: AuditConnector = MicroserviceAuditConnector
 }

--- a/app/uk/gov/hmrc/mobilemessages/services/MobileMessagesService.scala
+++ b/app/uk/gov/hmrc/mobilemessages/services/MobileMessagesService.scala
@@ -54,7 +54,7 @@ trait LiveMobileMessagesService extends MobileMessagesService with Auditor {
 
   private def messages(maybeSaUtr : Option[SaUtr])(implicit hc: HeaderCarrier, ec: ExecutionContext) : Future[Seq[MessageHeader]] =
     maybeSaUtr match {
-      case Some(utr) => entityResolverConnector.messages(utr)
+      case Some(utr) => entityResolverConnector.messages
       case _ => Future.successful(Seq.empty)
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -173,6 +173,11 @@ microservice {
       port = 8910
     }
 
+    entity-resolver {
+      host = localhost
+      port = 8015
+    }
+
     sa-message-renderer {
       host = localhost
       port = 8089

--- a/it/GetMessagesIntegrationSpec.scala
+++ b/it/GetMessagesIntegrationSpec.scala
@@ -115,7 +115,7 @@ class GetMessagesIntegrationSpec extends UnitSpec with MockitoSugar with ScalaFu
       withHeaders(("Accept", "application/vnd.hmrc.1.0+json"))
 
     def entityResolverGetMessagesReturns(messageResponseBody: String) {
-      givenThat(get(urlPathMatching(s"/message/sa/$utr")).
+      givenThat(get(urlPathMatching(s"/messages")).
         withQueryParam("read", equalTo("Both")).
         willReturn(aResponse().
           withBody(

--- a/it/GetMessagesIntegrationSpec.scala
+++ b/it/GetMessagesIntegrationSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import it.utils.WiremockServiceLocatorSugar
+import org.joda.time.{DateTime, LocalDate}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.Json
+import play.api.test.{FakeApplication, FakeRequest}
+import play.api.{GlobalSettings, Play}
+import uk.gov.hmrc.domain.SaUtr
+import uk.gov.hmrc.mobilemessages.controllers.{LiveMobileMessagesController, MobileMessagesController}
+import uk.gov.hmrc.play.test.UnitSpec
+
+/**
+  * Testcase to verify the capability of integration with the Messages on the Digital Platform
+  *
+  * 1. To get the list of messages for a given utr this service needs to call entity-resolver, parse and return its output
+  *
+  */
+class GetMessagesIntegrationSpec extends UnitSpec with MockitoSugar with ScalaFutures with WiremockServiceLocatorSugar with BeforeAndAfter {
+
+  "microservice get messages" should {
+
+    "return a list of messages returned by entity-resolver" in new Setup {
+      authContainsUserWith(utr)
+      entityResolverGetMessagesReturns(messageHeadersBody)
+
+      val messageHeadersResponse = messageController.getMessages(None)(request).futureValue
+      jsonBodyOf(messageHeadersResponse) shouldBe Json.parse(expectedGetMessagesResponse)
+    }
+  }
+
+  before {
+    startMockServer()
+    stubRegisterEndpoint(204)
+    Play.start(app)
+  }
+
+  after {
+    Play.stop()
+    stopMockServer()
+  }
+
+  val additionalConfiguration: Map[String, Any] = Map(
+    "appName" -> "application-name",
+    "appUrl" -> "http://microservice-name.service",
+    "microservice.services.entity-resolver.host" -> stubHost,
+    "microservice.services.entity-resolver.port" -> stubPort,
+    "microservice.services.auth.host" -> stubHost,
+    "microservice.services.auth.port" -> stubPort,
+    "microservice.services.message.host" -> stubHost,
+    "microservice.services.message.port" -> stubPort,
+    "auditing.enabled" -> "false"
+  )
+
+  object TestGlobal extends GlobalSettings
+  implicit val app = FakeApplication(
+    withGlobal = Some(TestGlobal),
+    additionalConfiguration = additionalConfiguration
+  )
+
+
+  trait Setup {
+    val validFromDate = new LocalDate(29348L)
+    val readTime = new DateTime(82347L)
+    val messageId = "messageId90342"
+    val utr = SaUtr("109238")
+
+    val messageHeadersBody =
+      s"""
+         |[
+         |  {
+         |    "id": "$messageId",
+         |    "subject": "message subject",
+         |    "validFrom": "${validFromDate.toString()}",
+         |    "readTime": "${readTime.toString()}",
+         |    "readTimeUrl": "readTimeUrl",
+         |    "sentInError": false
+         |  }
+         |]
+             """.stripMargin
+
+    val expectedGetMessagesResponse =
+      s"""
+         |[
+         |  {
+         |    "id": "$messageId",
+         |    "subject": "message subject",
+         |    "validFrom": "${validFromDate.toString()}",
+         |    "readTime": ${readTime.getMillis()},
+         |    "readTimeUrl": "readTimeUrl",
+         |    "sentInError": false
+         |  }
+         |]
+             """.stripMargin
+
+    val messageController: MobileMessagesController = LiveMobileMessagesController
+    val request = FakeRequest("GET", "/").
+      withHeaders(("Accept", "application/vnd.hmrc.1.0+json"))
+
+    def entityResolverGetMessagesReturns(messageResponseBody: String) {
+      givenThat(get(urlPathMatching(s"/message/sa/$utr")).
+        withQueryParam("read", equalTo("Both")).
+        willReturn(aResponse().
+          withBody(
+            messageResponseBody
+          )))
+    }
+
+    def authContainsUserWith(utr: SaUtr) = {
+      givenThat(get(urlMatching("/auth/authority*"))
+        .willReturn(aResponse().withStatus(200).withBody(
+          Json.parse(
+            s"""
+               | {
+               |    "confidenceLevel": 500,
+               |    "uri": "testUri",
+               |    "accounts": {
+               |        "sa": {
+               |            "utr": "$utr"
+               |         },
+               |         "paye": {
+               |            "nino": "BC233445B"
+               |         }
+               |     }
+               | }""".
+              stripMargin
+          )
+            .toString())))
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnectorSpec.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilemessages.connector
+
+import org.joda.time.{DateTime, LocalDate}
+import org.scalatest.concurrent.ScalaFutures
+import play.api.libs.json.{Json, Writes}
+import play.api.test.FakeApplication
+import play.twirl.api.Html
+import uk.gov.hmrc.domain.{Nino, SaUtr}
+import uk.gov.hmrc.mobilemessages.controller.StubApplicationConfiguration
+import uk.gov.hmrc.mobilemessages.domain.{MessageHeader, RenderMessageLocation}
+import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel
+import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.play.http.hooks.HttpHook
+import uk.gov.hmrc.play.http.logging.Authorization
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EntityResolverConnectorSpec extends UnitSpec
+  with WithFakeApplication
+  with ScalaFutures
+  with StubApplicationConfiguration {
+
+  override lazy val fakeApplication = FakeApplication(additionalConfiguration = config)
+
+  private trait Setup {
+    implicit lazy val hc = HeaderCarrier(Some(Authorization("some value")))
+
+    lazy val html = Html.apply("<div>some snippet</div>")
+    val saUtr = SaUtr("1234567890")
+    val nino = Nino("CS700100A")
+    val responseRenderer = RenderMessageLocation("sa-message-renderer","http://somelocation")
+    val messageHeader = MessageHeader("someId",
+                          subject="someSubject",
+                         validFrom =  LocalDate.now(),
+                         readTime= None,
+                         readTimeUrl="someUrl",
+                         sentInError=false)
+
+    lazy val http500Response = Future.failed(new Upstream5xxResponse("Error", 500, 500))
+    lazy val http400Response = Future.failed(new BadRequestException("bad request"))
+    lazy val http200ResponseEmpty = Future.successful(HttpResponse(200, Some(Json.toJson(Seq.empty[MessageHeader]))))
+    lazy val http200Response = Future.successful(HttpResponse(200, Some(Json.toJson(Seq(messageHeader,messageHeader,messageHeader)))))
+
+    lazy val ReadSuccessResult = Future.successful(HttpResponse(200, None, Map.empty, Some(html.toString())))
+    lazy val PostSuccessResult = Future.successful(HttpResponse(200, Some(Json.toJson(responseRenderer))))
+    lazy val PostConflictResult = Future.successful(HttpResponse(409, Some(Json.toJson(responseRenderer))))
+
+    lazy val responseGet: Future[HttpResponse] = http400Response
+    lazy val responsePost: Future[HttpResponse] = PostSuccessResult
+
+    implicit val authUser : Option[Authority] = Some(Authority(nino, ConfidenceLevel.L200, "someId"))
+
+    val httpStub = new HttpGet with HttpPost {
+      override val hooks: Seq[HttpHook] = NoneRequired
+      private var lastUrl: String = "never called"
+      def lastUrlCalled = lastUrl
+
+      override protected def doGet(url: String)
+                                  (implicit hc: HeaderCarrier): Future[HttpResponse] = {
+        lastUrl = url
+        responseGet
+      }
+
+      override protected def doPost[A](url: String, body: A, headers: Seq[(String, String)])
+                                      (implicit wts: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
+        lastUrl = url
+        responsePost
+      }
+
+      override protected def doPostString(url: String, body: String, headers: Seq[(String, String)])
+                                         (implicit hc: HeaderCarrier): Future[HttpResponse] = {
+        lastUrl = url
+        responsePost
+      }
+
+      override protected def doFormPost(url: String, body: Map[String, Seq[String]])
+                                       (implicit hc: HeaderCarrier): Future[HttpResponse] = {
+        lastUrl = url
+        responsePost
+      }
+
+      override protected def doEmptyPost[A](url: String)
+                                           (implicit hc: HeaderCarrier): Future[HttpResponse] = {
+        lastUrl = url
+        responsePost
+      }
+    }
+
+    val entityResolverUrl = "somebase-url"
+
+    val connector = new EntityResolverConnector {
+      override def http = httpStub
+
+      override val entityResolverBaseUrl: String = entityResolverUrl
+    }
+  }
+
+  "entityResolverConnector messages" should {
+
+    "throw BadRequestException when a 400 response is returned" in new Setup {
+      override lazy val responseGet = http400Response
+        intercept[BadRequestException] {
+          await(connector.messages(saUtr))
+      }
+    }
+
+    "throw Upstream5xxResponse when a 500 response is returned" in new Setup {
+      override lazy val responseGet = http500Response
+      intercept[Upstream5xxResponse] {
+        await(connector.messages(saUtr))
+      }
+    }
+
+    "return empty response when a 200 response is received with an empty payload" in new Setup {
+      override lazy val responseGet = http200ResponseEmpty
+      connector.messages(saUtr).futureValue shouldBe Seq.empty
+    }
+
+    "return a list of items when a 200 response is received with a payload" in new Setup {
+      override lazy val responseGet = http200Response
+      connector.messages(saUtr).futureValue shouldBe Seq(messageHeader,messageHeader,messageHeader)
+    }
+
+    "be calling entity resolver with the correct url" in new Setup {
+      override lazy val responseGet = http200Response
+      await(connector.messages(saUtr))
+      httpStub.lastUrlCalled shouldBe s"$entityResolverUrl/message/sa/${saUtr.utr}?read=Both"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/connector/EntityResolverConnectorSpec.scala
@@ -118,31 +118,31 @@ class EntityResolverConnectorSpec extends UnitSpec
     "throw BadRequestException when a 400 response is returned" in new Setup {
       override lazy val responseGet = http400Response
         intercept[BadRequestException] {
-          await(connector.messages(saUtr))
+          await(connector.messages)
       }
     }
 
     "throw Upstream5xxResponse when a 500 response is returned" in new Setup {
       override lazy val responseGet = http500Response
       intercept[Upstream5xxResponse] {
-        await(connector.messages(saUtr))
+        await(connector.messages)
       }
     }
 
     "return empty response when a 200 response is received with an empty payload" in new Setup {
       override lazy val responseGet = http200ResponseEmpty
-      connector.messages(saUtr).futureValue shouldBe Seq.empty
+      connector.messages.futureValue shouldBe Seq.empty
     }
 
     "return a list of items when a 200 response is received with a payload" in new Setup {
       override lazy val responseGet = http200Response
-      connector.messages(saUtr).futureValue shouldBe Seq(messageHeader,messageHeader,messageHeader)
+      connector.messages.futureValue shouldBe Seq(messageHeader,messageHeader,messageHeader)
     }
 
     "be calling entity resolver with the correct url" in new Setup {
       override lazy val responseGet = http200Response
-      await(connector.messages(saUtr))
-      httpStub.lastUrlCalled shouldBe s"$entityResolverUrl/message/sa/${saUtr.utr}?read=Both"
+      await(connector.messages)
+      httpStub.lastUrlCalled shouldBe s"$entityResolverUrl/messages?read=Both"
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilemessages/connector/MessagesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/connector/MessagesConnectorSpec.scala
@@ -94,34 +94,6 @@ class MessagesConnectorSpec
 
   }
 
-  "messagesConnector messages" should {
-
-    "throw BadRequestException when a 400 response is returned" in new Setup {
-      override lazy val responseGet = http400Response
-        intercept[BadRequestException] {
-          await(connector.messages(saUtr))
-      }
-    }
-
-    "throw Upstream5xxResponse when a 500 response is returned" in new Setup {
-      override lazy val responseGet = http500Response
-      intercept[Upstream5xxResponse] {
-        await(connector.messages(saUtr))
-      }
-    }
-
-    "return empty response when a 200 response is received with an empty payload" in new Setup {
-      override lazy val responseGet = http200ResponseEmpty
-      await(connector.messages(saUtr)) shouldBe Seq.empty
-    }
-
-    "return a list of items when a 200 response is received with a payload" in new Setup {
-      override lazy val responseGet = http200Response
-      await(connector.messages(saUtr)) shouldBe Seq(messageHeader,messageHeader,messageHeader)
-    }
-
-  }
-
   "messagesConnector readMessageContent" should {
 
     "return successfully with html partial" in new Setup {

--- a/test/uk/gov/hmrc/mobilemessages/controller/MobileMessagesControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/controller/MobileMessagesControllerSpec.scala
@@ -87,7 +87,6 @@ class MobileMessagesControllerSpec extends UnitSpec with WithFakeApplication wit
       contentAsJson(result).as[Seq[MessageHeader]] shouldBe Seq.empty[MessageHeader]
     }
 
-
     "return an empty list of messages successfully when journeyId is supplied" in new Success {
 
       val result: Result = await(controller.getMessages(journeyId)(emptyRequestWithAcceptHeader))
@@ -102,14 +101,6 @@ class MobileMessagesControllerSpec extends UnitSpec with WithFakeApplication wit
 
       status(result) shouldBe 200
       contentAsJson(result).as[Seq[MessageHeader]] shouldBe messageHeaderList
-    }
-
-    "call the EntityResolverConnector with the right utr" in new SuccessWithMessages {
-
-      val result: Result = await(controller.getMessages()(emptyRequestWithAcceptHeader))
-
-      status(result) shouldBe 200
-      testEntityResolverConnector.lastUtrPassed shouldBe saUtrVal
     }
 
     "return forbidden when authority record does not have correct confidence level" in new AuthWithLowCL {

--- a/test/uk/gov/hmrc/mobilemessages/controller/MobileMessagesControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/controller/MobileMessagesControllerSpec.scala
@@ -104,6 +104,14 @@ class MobileMessagesControllerSpec extends UnitSpec with WithFakeApplication wit
       contentAsJson(result).as[Seq[MessageHeader]] shouldBe messageHeaderList
     }
 
+    "call the EntityResolverConnector with the right utr" in new SuccessWithMessages {
+
+      val result: Result = await(controller.getMessages()(emptyRequestWithAcceptHeader))
+
+      status(result) shouldBe 200
+      testEntityResolverConnector.lastUtrPassed shouldBe saUtrVal
+    }
+
     "return forbidden when authority record does not have correct confidence level" in new AuthWithLowCL {
       val result = await(controller.getMessages()(emptyRequestWithAcceptHeader))
 

--- a/test/uk/gov/hmrc/mobilemessages/controller/Setup.scala
+++ b/test/uk/gov/hmrc/mobilemessages/controller/Setup.scala
@@ -71,12 +71,7 @@ class TestEntityResolverConnector(result:Seq[MessageHeader]) extends EntityResol
 
   override val entityResolverBaseUrl: String = "someUrl"
 
-  private var lastUtr = SaUtr("utr not established")
-  def lastUtrPassed = lastUtr
-
-  override def messages(utr: SaUtr)
-                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = {
-    lastUtr = utr
+  override def messages(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = {
     Future.successful(result)
   }
 }
@@ -118,8 +113,8 @@ trait Setup {
 
   val now = DateTimeUtils.now
   val messages =
-    s"""[{"id":"543e8c6001000001003e4a9e","subject":"You have a new tax statement","validFrom":"${now.minusDays(3).toLocalDate}","readTime":${now.minusDays(1).getMillis},"readTimeUrl":"/message/sa/${saUtrVal.value}/543e8c6001000001003e4a9e/read-time","sentInError":false},
-       |{"id":"643e8c5f01000001003e4a8f","subject":"Stopping Self Assessment","validFrom":"${now.toLocalDate}","readTimeUrl":"/message/sa/${saUtrVal.value}/643e8c5f01000001003e4a8f/read-time","sentInError":false}]""".stripMargin
+    s"""[{"id":"543e8c6001000001003e4a9e","subject":"You have a new tax statement","validFrom":"${now.minusDays(3).toLocalDate}","readTime":${now.minusDays(1).getMillis},"readTimeUrl":"/entities/some-entityId/messages/543e8c6001000001003e4a9e/read-time","sentInError":false},
+       |{"id":"643e8c5f01000001003e4a8f","subject":"Stopping Self Assessment","validFrom":"${now.toLocalDate}","readTimeUrl":"/entities/some-entityId/messages/643e8c5f01000001003e4a8f/read-time","sentInError":false}]""".stripMargin
 
   lazy val html = Html.apply("<div>some snippet</div>")
 

--- a/test/uk/gov/hmrc/mobilemessages/controller/Setup.scala
+++ b/test/uk/gov/hmrc/mobilemessages/controller/Setup.scala
@@ -58,8 +58,6 @@ class TestMessageConnector(result:Seq[MessageHeader], html:Html) extends Message
 
   override val messageBaseUrl: String = "someUrl"
 
-  override def messages(utr: SaUtr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[MessageHeader]] = throw new Exception("Should call entity resolver for the messages")
-
   override def readMessageContent(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext, auth: Option[uk.gov.hmrc.mobilemessages.connector.Authority]): Future[Html] = Future.successful(html)
 
   override val provider: String = "provider"


### PR DESCRIPTION
…er connector instead of calling the Message directly

The get message list will now need to call entity-resolver instead of hitting the message directly.