### PR TITLE
NGC-637 - Add caching HTTP response headers to NGC mobile-messages service

### DIFF
--- a/app/uk/gov/hmrc/mobilemessages/config/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/mobilemessages/config/microserviceGlobal.scala
@@ -25,11 +25,13 @@ import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.api.config.{ServiceLocatorConfig, ServiceLocatorRegistration}
 import uk.gov.hmrc.api.connector.ServiceLocatorConnector
 import uk.gov.hmrc.api.controllers._
+import uk.gov.hmrc.api.filters.CacheControlFilter
 import uk.gov.hmrc.mobilemessages.controllers._
 import uk.gov.hmrc.play.audit.filters.AuditFilter
 import uk.gov.hmrc.play.auth.controllers.AuthParamsControllerConfig
 import uk.gov.hmrc.play.auth.microservice.filters.AuthorisationFilter
 import uk.gov.hmrc.play.config.{AppName, ControllerConfig, RunMode}
+import uk.gov.hmrc.play.filters.NoCacheFilter
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.filters.LoggingFilter
 import uk.gov.hmrc.play.microservice.bootstrap.DefaultMicroserviceGlobal
@@ -76,6 +78,10 @@ object MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Se
   override val authFilter = Some(MicroserviceAuthFilter)
 
   override val slConnector: ServiceLocatorConnector = ServiceLocatorConnector(WSHttp)
+
+  val cacheFilter = CacheControlFilter.fromConfig(CacheControlFilter.configKey)
+
+  override val microserviceFilters = defaultMicroserviceFilters.filterNot( _.isInstanceOf[NoCacheFilter.type] ) :+ cacheFilter
 
   override implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -150,6 +150,10 @@ provider = "GGW"
 token = "some token"
 id = "NGC"
 
+apiCaching {
+  "/messages" = 3600
+}
+
 microservice {
   metrics {
     graphite {

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -29,7 +29,7 @@ private object AppDependencies {
   private val playUrlBindersVersion = "1.0.0"
   private val playConfigVersion = "2.0.1"
   private val domainVersion = "3.5.0"
-  private val playHmrcApiVersion = "0.5.0"
+  private val playHmrcApiVersion = "0.6.0"
 
   private val scalaTestVersion = "2.2.6"
   private val pegdownVersion = "1.6.0"


### PR DESCRIPTION
Allow /messages endpoint response to be cached