### PR TITLE
[NGC-2789][ph] revert some changes and fix sa-message-renderer bug

### DIFF
--- a/it/uk/gov/hmrc/mobilemessages/controllers/action/AccountAccessControlISpec.scala
+++ b/it/uk/gov/hmrc/mobilemessages/controllers/action/AccountAccessControlISpec.scala
@@ -4,8 +4,8 @@ import org.scalatest.concurrent.Eventually
 import uk.gov.hmrc.auth.core.ConfidenceLevel
 import uk.gov.hmrc.auth.core.ConfidenceLevel.{L200, L50}
 import uk.gov.hmrc.domain.{Nino, SaUtr}
-import uk.gov.hmrc.http.{ForbiddenException, HeaderCarrier, HttpResponse, UnauthorizedException}
-import utils.AuthStub.{authRecordExists, authRecordExistsWithoutNino}
+import uk.gov.hmrc.http._
+import utils.AuthStub._
 import utils.BaseISpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -42,6 +42,13 @@ class AccountAccessControlISpec extends BaseISpec with Eventually  {
       }
     }
 
+    "fail if no auth/authority returns unauthorised" in {
+      unauthorised
+
+      intercept[Upstream4xxResponse] {
+        await(AccountAccessControl.grantAccess())
+      }
+    }
   }
 }
 

--- a/it/utils/AuthStub.scala
+++ b/it/utils/AuthStub.scala
@@ -8,14 +8,22 @@ import uk.gov.hmrc.domain.Nino
 
 object AuthStub {
   def authRecordExists(nino: Nino = Nino("BC233445B"), confidenceLevel: ConfidenceLevel = L200): Unit = {
+    stubFor(get(urlEqualTo("/auth/authority")).willReturn(aResponse().withStatus(200).withBody(obj("uri" -> "uri").toString())))
+
     stubFor(post(urlEqualTo("/auth/authorise")).withRequestBody(equalToJson(
       """{ "authorise": [], "retrieve": ["nino","confidenceLevel"] }""".stripMargin, true, false)).willReturn(
       aResponse().withStatus(200).withBody(obj("confidenceLevel" -> confidenceLevel.level, "nino" -> nino.nino).toString)))
   }
 
   def authRecordExistsWithoutNino: Unit = {
+    stubFor(get(urlEqualTo("/auth/authority")).willReturn(aResponse().withStatus(200).withBody(obj("uri" -> "uri").toString())))
+
     stubFor(post(urlEqualTo("/auth/authorise")).withRequestBody(equalToJson(
       """{ "authorise": [], "retrieve": ["nino","confidenceLevel"] }""".stripMargin, true, false)).willReturn(
         aResponse().withStatus(200).withBody(obj("confidenceLevel" -> L200.level).toString)))
+  }
+
+  def unauthorised: Unit = {
+    stubFor(get(urlEqualTo("/auth/authority")).willReturn(aResponse().withStatus(401)))
   }
 }

--- a/test/uk/gov/hmrc/mobilemessages/acceptance/microservices/AuthServiceMock.scala
+++ b/test/uk/gov/hmrc/mobilemessages/acceptance/microservices/AuthServiceMock.scala
@@ -25,7 +25,9 @@ import uk.gov.hmrc.domain.Nino
 class AuthServiceMock {
   def token = "authToken9349872"
 
-  def authRecordExists(nino: Nino = Nino("BC233445B"), confidenceLevel: ConfidenceLevel = L200): Unit = {
+  def authRecordExists(nino: Nino = Nino("BC233445B"), confidenceLevel: ConfidenceLevel = L200, uri: String = "uri"): Unit = {
+    stubFor(get(urlEqualTo("/auth/authority")).willReturn(aResponse().withStatus(200).withBody(obj("uri" -> uri).toString())))
+
     stubFor(post(urlEqualTo("/auth/authorise")).withRequestBody(equalToJson(
       """{ "authorise": [], "retrieve": ["nino","confidenceLevel"] }""".stripMargin, true, false)).willReturn(
         aResponse().withStatus(200).withBody(obj("confidenceLevel" -> confidenceLevel.level, "nino" -> nino.nino).toString)))

--- a/test/uk/gov/hmrc/mobilemessages/connector/MessagesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilemessages/connector/MessagesConnectorSpec.scala
@@ -119,7 +119,7 @@ class MessagesConnectorSpec
     lazy val PostSuccessResult = Future.successful(HttpResponse(200, Some(toJson(responseRenderer))))
     lazy val PostConflictResult = Future.successful(HttpResponse(409, Some(toJson(responseRenderer))))
 
-    implicit val authUser: Option[Authority] = Some(Authority(Nino("CS700100A"), L200))
+    implicit val authUser: Option[Authority] = Some(Authority(Nino("CS700100A"), L200, "someId"))
 
     val connector = MessageConnector
 
@@ -168,25 +168,25 @@ class MessagesConnectorSpec
     "throw BadRequestException when a 400 response is returned" in new Setup {
       testMessageRenderer.failsWith(status = 400, path = renderPath)
       intercept[BadRequestException] {
-        await(connector.render(message.convertedFrom(messageBodyToRender)))
+        await(connector.render(message.convertedFrom(messageBodyToRender), hc))
       }
     }
 
     "throw Upstream5xxResponse when a 500 response is returned" in new Setup {
       testMessageRenderer.failsWith(status = 500, path = renderPath)
       intercept[Upstream5xxResponse] {
-        await(connector.render(message.convertedFrom(messageBodyToRender)))
+        await(connector.render(message.convertedFrom(messageBodyToRender), hc))
       }
     }
 
     s"return empty response when a 200 response is received with an empty payload" in new Setup {
       testMessageRenderer.successfullyRenders(messageBodyToRender, overrideBody = Some(""))
-      await(connector.render(message.convertedFrom(messageBodyToRender))).body shouldBe ""
+      await(connector.render(message.convertedFrom(messageBodyToRender), hc)).body shouldBe ""
     }
 
     "return a rendered message when a 200 response is received with a payload" in new Setup {
       testMessageRenderer.successfullyRenders(messageBodyToRender)
-      await(connector.render(message.convertedFrom(messageBodyToRender))).body shouldBe testMessageRenderer.rendered(messageBodyToRender)
+      await(connector.render(message.convertedFrom(messageBodyToRender), hc)).body shouldBe testMessageRenderer.rendered(messageBodyToRender)
     }
   }
 

--- a/test/uk/gov/hmrc/mobilemessages/controllers/Setup.scala
+++ b/test/uk/gov/hmrc/mobilemessages/controllers/Setup.scala
@@ -45,7 +45,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TestAccessControl(nino: Option[Nino], saUtr: Option[SaUtr]) extends AccountAccessControl{
   override def grantAccess()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Authority] =
-    Future(Authority(nino.getOrElse(throw new Exception("Invalid nino")), L200))
+    Future(Authority(nino.getOrElse(throw new Exception("Invalid nino")), L200, "some-auth-id"))
 }
 
 class TestMessageConnector(result: Seq[MessageHeader], html: Html, message: Message) extends MessageConnector {
@@ -60,7 +60,7 @@ class TestMessageConnector(result: Seq[MessageHeader], html: Html, message: Mess
 
   override def getMessageBy(id: MessageId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Message] = Future.successful(message)
 
-  override def render(message: Message)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Html] = Future.successful(html)
+  override def render(message: Message, hc: HeaderCarrier)(implicit ec: ExecutionContext, auth: Option[Authority]): Future[Html] = Future.successful(html)
 }
 
 class TestMobileMessagesService(testAccessControl: TestAccessControl, mobileMessageConnector: MessageConnector, testAuditConnector: AuditConnector) extends LiveMobileMessagesService {


### PR DESCRIPTION
This PR is to fix a bug exposed by the MessagesSpec in next-generation-consumer-acceptance-tests. The bug made it to master because I ran the wrong shell script when testing a change and thought MessagesSpec had passed.

mobile-messages makes a call to the sa-message-renderer service to render messages to HTML format. mobile-messages is a backend service hosted in the protected zone which uses the auth client for auth whereas sa-message-renderer is a frontend service which uses the frontend auth library. This causes an auth issue for which there was a workaround - mobile-messages attempted to reconstruct the front end auth headers using a combination of hard-coded values and data from the auth/authority endpoint. 

This code was wrongly removed by a previous PR to upgrade the auth library and this caused the bug.

Having tested and debugged this interaction using the MessagesSpec it turns out that 2 of the header values that were being set are actually needed: SessionKeys.authToken and SesxsionKeys.userId. The auth token can be retrieved from the header carrier. However the 'user id' actually requires the following relative url value (outlined here: https://github.com/hmrc/auth/blob/master/conf/app.routes):
  /auth/session/{sessionId}

mobile-messages set this header to the value of the uri field from a call to /auth/authority. In sa-message-renderer the frontend auth library compares the header with the value returned by a call to auth/authority and if they don't match the render request is rejected as unauthorised.

The problem is that the uri value cannot be reconstructed using the auth-client library in mobile-messages. The nearest match is a deprecated uri retrieval. However it is an absolute url of the form:
  protocol://host:port/user-details/id/{id}
where the id field does not correspond to the sessionId required by the frontend auth library uri.

Therefore I have added a call to auth/authority to retrieve the uri as before. This sits alongside the auth-client 'authorised' call.

It is not ideal that we are attempting to workaround auth in this way. The workaround is likely to be brittle - changes to the sa-message-rendering auth libraries might break this. Other solutions considered include:
1. Splitting sa-message-renderer into frontend and backend services. We would call the backend service and then no auth workaround is required. However this is not trivial and is work for another team which s currently being replaced.
2. Performing rendering in mobile-messages. I tried this but it is more complex than it sounds and would have meant largely re-implementing the sa-message-rendering service so seemed like a worse solution than the workaround. 
3. Discussing a solution with the auth team and the messaging team. Perhaps auth could add some functionality into the auth client library to support his usage.


